### PR TITLE
fix(paraswap): use wildcard

### DIFF
--- a/dappwhitelist.json
+++ b/dappwhitelist.json
@@ -219,7 +219,7 @@
         },
         {
           "name": "Paraswap",
-          "domain": "app.paraswap.io",
+          "domain": "*.paraswap.io",
           "token": "PSP",
           "contracts": [
             { "address": "0xdef171fe48cf0115b1d80b88dc8eab59176fee57" },


### PR DESCRIPTION
Possible other subdomains identified with trace https://app.datadoghq.eu/apm/trace/1942989268503265158?colorBy=service&env=prd&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=6446361792722101154&spanViewType=metadata&timeHint=1663593256213.0042