### PR TITLE
[BACK-4056] add seaport contract

### DIFF
--- a/dappwhitelist.json
+++ b/dappwhitelist.json
@@ -15,7 +15,8 @@
             { "address": "0x5b3256965e7c3cf26e11fcaf296dfc8807c01073" },
             { "address": "0x7be8076f4ea4a4ad08075c2508e481d6c946d12b" },
             { "address": "0x00000000006c3852cbef3e08e8df289169ede581" },
-            { "address": "0x7f268357a8c2552623316e2562d90e642bb538e5" }
+            { "address": "0x7f268357a8c2552623316e2562d90e642bb538e5" },
+            { "address": "0x7e1e3334130355799f833ffec2d731bca3e68af6" }
           ]
         },
         {
@@ -79,7 +80,8 @@
             { "address": "0x60f80121c31a0d46b5279700f9df786054aa5ee5" },
             { "address": "0xd07dc4262bcdbf85190c01c996b4c06a461d2430" },
             { "address": "0x1cf0df2a5a20cd61d68d4489eebbf85b8d39e18a" },
-            { "address": "0xfdff6b56cce39482032b27140252ff4f16432785" }
+            { "address": "0xfdff6b56cce39482032b27140252ff4f16432785" },
+            { "address": "0x7e1e3334130355799f833ffec2d731bca3e68af6" }
           ]
         },
         {
@@ -6346,7 +6348,8 @@
           "contracts": [
             { "address": "0x00000000A50BB64b4BbEcEB18715748DfacE08af" },
             { "address": "0x0000000035634B55f3D99B071B5A354f48e10BEF" },
-            { "address": "0x83C8F28c26bF6aaca652Df1DbBE0e1b56F8baBa2" }
+            { "address": "0x83C8F28c26bF6aaca652Df1DbBE0e1b56F8baBa2" },
+            { "address": "0x7e1e3334130355799f833ffec2d731bca3e68af6" }
           ]
         },
         {


### PR DESCRIPTION
Update domains opensea, rarible and gem.xyz with seaport 1.1 contract