### PR TITLE
remove address from genie.xyc

### DIFF
--- a/allowlist.json
+++ b/allowlist.json
@@ -6397,7 +6397,6 @@
         "domain": "genie.xyz",
         "token": null,
         "contracts": [
-          { "address": "0x2af4b707e1DCe8fC345f38CfeeAA2421e54976d5" },
           { "address": "0x0a267cf51ef038fc00e71801f5a524aec06e4f07" }
         ]
       },


### PR DESCRIPTION
Ticket BACK-4098

## Changes

  Removed the following contract address from genie.xyz as it was not linked to this dapp.
  [0x2af4b707e1DCe8fC345f38CfeeAA2421e54976d5](https://etherscan.io/address/0x2af4b707e1DCe8fC345f38CfeeAA2421e54976d5)
