### PR TITLE
add 1 missing contract to 1inch

### DIFF
--- a/allowlist.json
+++ b/allowlist.json
@@ -65,7 +65,8 @@
           { "address": "0x5fe3b8b19949c04da3f578c6468f3d444cd7a9bb" },
           { "address": "0x7e1e3334130355799f833ffec2d731bca3e68af6" },
           { "address": "0xdac17f958d2ee523a2206206994597c13d831ec7" },
-          { "address": "0x1111111254eeb25477b68fb85ed929f73a960582" }
+          { "address": "0x1111111254eeb25477b68fb85ed929f73a960582" },
+          { "address": "0x119c71d3bbac22029622cbaec24854d3d32d2828" }
         ]
       },
       {


### PR DESCRIPTION
## Changes
Add 0x119c71d3bbac22029622cbaec24854d3d32d2828 to 1inch domain

## Reason
It’s purpose is for placing limit orders on 1inch ethereum. It was flagged as a legitimate contract address by @krboktv from the 1inch team on the Ledger x 1inch telegram group.

