### PR TITLE
fix(manifold): correct user facing dapp domain

### DIFF
--- a/allowlist.json
+++ b/allowlist.json
@@ -7098,7 +7098,7 @@
       },
       {
         "name": "Manifold",
-        "domain": "manifold.xyz",
+        "domain": "app.manifold.xyz",
         "token":null,
         "contracts": [
           { "address": "0x2d3fC875de7Fe7Da43AD0afa0E7023c9B91D06b1" },


### PR DESCRIPTION
## Changes

- Dapp(s)
  - added : ...
  - removed : ...
  - updated : manifold
  
- Contract(s)
  - added : ...
  - removed : ...
  - updated : ...

## Reason

dapp url is app.manifold.xyz

![image](https://user-images.githubusercontent.com/55251330/209804919-647f71a0-31e6-4875-a1a6-1788a410537d.png)
