### PR TITLE
fix(gem.xyz): DApp uses www.gem.xyz excplicitly

### DIFF
--- a/allowlist.json
+++ b/allowlist.json
@@ -6487,7 +6487,7 @@
       },
       {
         "name": "Gem",
-        "domain": "gem.xyz",
+        "domain": "www.gem.xyz",
         "token": null,
         "contracts": [
           { "address": "0x00000000A50BB64b4BbEcEB18715748DfacE08af" },


### PR DESCRIPTION
## Changes

- Dapp(s)
  - added : ...
  - removed : ...
  - updated : gem.xyz
  
- Contract(s)
  - added : ...
  - removed : ...
  - updated : ...

## Reason

Usually a domain will use its `www` subdomain as alias but for gem it seems to be the other way around with the domain being an alias redirecting to their `www` subdomain.