### PR TITLE
add: mint.fun

### DIFF
--- a/allowlist.json
+++ b/allowlist.json
@@ -7097,17 +7097,6 @@
         ]
       },
       {
-        "name": "Manifold",
-        "domain": "app.manifold.xyz",
-        "token":null,
-        "contracts": [
-          { "address": "0x2d3fC875de7Fe7Da43AD0afa0E7023c9B91D06b1" },
-          { "address": "0x6bf5ed59dE0E19999d264746843FF931c0133090" },
-          { "address": "0x0385603ab55642cb4Dd5De3aE9e306809991804f" },
-          { "address": "0xaD2184FB5DBcfC05d8f056542fB25b04fa32A95D" }
-        ]
-      },
-      {
         "name": "RTFKT",
         "domain": "rtfkt.com",
         "token":null,
@@ -7229,6 +7218,14 @@
         "token":null,
         "contracts": [
 
+        ]
+      },
+      {
+        "name": "Mint.fun",
+        "domain": "mint.fun",
+        "token":null,
+        "contracts": [
+        
         ]
       }
     ],


### PR DESCRIPTION
## Changes

- Dapp(s)
  - added : mint.fun
  - removed : ...
  - updated : ...
  
- Contract(s)
  - added : ...
  - removed : ...
  - updated : ...

## Reason
We removed manifold because their contracts don't follow erc721 standards. Therefore we were getting many false positive warnings on Ledger Connect.