### PR TITLE
Incorporating new entries from Kleros Curate still 10 Sep 2023

### DIFF
--- a/dapps/bridge.base.org/dapp-allowlist.json
+++ b/dapps/bridge.base.org/dapp-allowlist.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "$schema": "../dapp-allowlist.schema.json",
+  "name": "Base",
+  "domain": "bridge.base.org",
+  "chains": {
+    "ethereum": [
+      {
+        "address": "0x49048044d57e1c92a77f79988d21fa8faf74e97e"
+      }
+    ]
+  }
+}

--- a/dapps/bridge.linea.build/dapp-allowlist.json
+++ b/dapps/bridge.linea.build/dapp-allowlist.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "$schema": "../dapp-allowlist.schema.json",
+  "name": "Linea",
+  "domain": "bridge.linea.build",
+  "chains": {
+    "ethereum": [
+      {
+        "address": "0xd19d4b5d358258f05d7b411e21a1460d11b0876f"
+      }
+    ]
+  }
+}

--- a/dapps/curate.kleros.io/dapp-allowlist.json
+++ b/dapps/curate.kleros.io/dapp-allowlist.json
@@ -15,6 +15,12 @@
       },
       {
         "address": "0x957a53a994860be4750810131d9c876b2f52d6e1"
+      },
+      {
+        "address": "0x70533554fe5c17caf77fe530f77eab933b92af60"
+      },
+      {
+        "address": "0x66260c69d03837016d88c9877e61e08ef74c59f2"
       }
     ]
   }

--- a/dapps/mint.eigenlayer.xyz/dapp-allowlist.json
+++ b/dapps/mint.eigenlayer.xyz/dapp-allowlist.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "$schema": "../dapp-allowlist.schema.json",
+  "name": "Eigenlayer",
+  "domain": "mint.eigenlayer.xyz",
+  "chains": {
+    "ethereum": [
+      {
+        "address": "0x8d0802559775c70fb505f22988a4fd4a4f6d3b62"
+      }
+    ]
+  }
+}

--- a/dapps/portal.zksync.io/dapp-allowlist.json
+++ b/dapps/portal.zksync.io/dapp-allowlist.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "$schema": "../dapp-allowlist.schema.json",
+  "name": "Zksync",
+  "domain": "portal.zksync.io",
+  "chains": {
+    "ethereum": [
+      {
+        "address": "0x32400084c286cf3e17e7b677ea9583e60a000324"
+      }
+    ]
+  }
+}

--- a/dapps/starkgate.starknet.io/dapp-allowlist.json
+++ b/dapps/starkgate.starknet.io/dapp-allowlist.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "$schema": "../dapp-allowlist.schema.json",
+  "name": "Starknet",
+  "domain": "starkgate.starknet.io",
+  "chains": {
+    "ethereum": [
+      {
+        "address": "0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419"
+      }
+    ]
+  }
+}

--- a/dapps/swap.defillama.com/dapp-allowlist.json
+++ b/dapps/swap.defillama.com/dapp-allowlist.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "$schema": "../dapp-allowlist.schema.json",
+  "name": "Defillama",
+  "domain": "swap.defillama.com",
+  "chains": {
+    "polygon": [
+      {
+        "address": "0xdef1c0ded9bec7f1a1670819833240f027b25eff"
+      },
+      {
+        "address": "0xb31d1b1ea48ce4bf10ed697d44b747287e785ad4"
+      }
+    ],
+    "ethereum": [
+      {
+        "address": "0x6131b5fae19ea4f9d964eac0408e4408b66337b5"
+      },
+      {
+        "address": "0xdef171fe48cf0115b1d80b88dc8eab59176fee57"
+      },
+      {
+        "address": "0xf6a94dfd0e6ea9ddfdffe4762ad4236576136613"
+      }
+    ],
+    "gnosis": [
+      {
+        "address": "0x1111111254fb6c44bac0bed2854e76f90643097d"
+      },
+      {
+        "address": "0x40a50cf069e992aa4536211b23f286ef88752187"
+      }
+    ]
+  }
+}

--- a/dapps/thegraph.com/dapp-allowlist.json
+++ b/dapps/thegraph.com/dapp-allowlist.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "$schema": "../dapp-allowlist.schema.json",
+  "name": "Thegraph",
+  "domain": "thegraph.com",
+  "chains": {
+    "ethereum": [
+      {
+        "address": "0xf55041e37e12cd407ad00ce2910b8269b01263b9"
+      }
+    ]
+  }
+}

--- a/dapps/zora.co/dapp-allowlist.json
+++ b/dapps/zora.co/dapp-allowlist.json
@@ -1,21 +1,24 @@
 {
-  "schemaVersion" : 1,
-  "$schema" : "../dapp-allowlist.schema.json",
-  "name" : "Zora",
-  "domain" : "zora.co",
-  "chains" : {
-    "ethereum" : [
+  "schemaVersion": 1,
+  "$schema": "../dapp-allowlist.schema.json",
+  "name": "Zora",
+  "domain": "zora.co",
+  "chains": {
+    "ethereum": [
       {
-        "address" : "0x850A7c6fE2CF48eea1393554C8A3bA23f20CC401"
+        "address": "0x850A7c6fE2CF48eea1393554C8A3bA23f20CC401"
       },
       {
-        "address" : "0x909e9efE4D87d1a6018C2065aE642b6D0447bc91"
+        "address": "0x909e9efE4D87d1a6018C2065aE642b6D0447bc91"
       },
       {
-        "address" : "0xCCA379FDF4Beda63c4bB0e2A3179Ae62c8716794"
+        "address": "0xCCA379FDF4Beda63c4bB0e2A3179Ae62c8716794"
       },
       {
-        "address" : "0x9641169A1374b77E052E1001c5a096C29Cd67d35"
+        "address": "0x9641169A1374b77E052E1001c5a096C29Cd67d35"
+      },
+      {
+        "address": "0x1a0ad011913a150f69f6a19df447a0cfd9551054"
       }
     ]
   }

--- a/klerosCDN_to_Github.py
+++ b/klerosCDN_to_Github.py
@@ -58,7 +58,26 @@ query_results = response_data["data"]["litems"]
 # Step 2: Extract the key1 (domain) and key0 (EVM address)
 #  values from the query results
 domain_address_map = {}
-chain_id_map = {"1": "ethereum", "137": "polygon", "100": "gnosis", "56": "bsc"}
+chain_id_map = {
+    "1": "ethereum",
+    "56": "bsc",
+    "100": "gnosis",
+    "137": "polygon",
+    "8453": "base",
+    "42161": "arbitrum",
+    "1284": "moonbeam",
+    "59144": "linea",
+    "10": "optimism",
+    "250": "fantom",
+    "1285": "moonriver",
+    "43114": "avalanche",
+    "25": "cronos",
+    "199": "bittorrent",
+    "1101": "polygonzkevm",
+    "1111": "wemix",
+    "534352": "scroll",
+    "42220": "celo",
+}
 
 # For logging purposes
 added_domains = set()


### PR DESCRIPTION
## Changes

- Dapp(s)

  - added : bridge.base.org, mint.eigenlayer.xyz, starkgate.starknet.io, swap.defillama.com, bridge.linea.build, portal.zksync.io, thegraph.com
  - removed : ...
  - updated : curate.kleros.io, zora.co

- Contract(s)

  - added : swap.defillama.com:gnosis:0x1111111254fb6c44bac0bed2854e76f90643097d, bridge.linea.build:ethereum:0xd19d4b5d358258f05d7b411e21a1460d11b0876f, swap.defillama.com:ethereum:0xf6a94dfd0e6ea9ddfdffe4762ad4236576136613, swap.defillama.com:gnosis:0x40a50cf069e992aa4536211b23f286ef88752187, curate.kleros.io:gnosis:0x70533554fe5c17caf77fe530f77eab933b92af60, bridge.base.org:ethereum:0x49048044d57e1c92a77f79988d21fa8faf74e97e, swap.defillama.com:ethereum:0xdef171fe48cf0115b1d80b88dc8eab59176fee57, curate.kleros.io:gnosis:0x66260c69d03837016d88c9877e61e08ef74c59f2, swap.defillama.com:ethereum:0x6131b5fae19ea4f9d964eac0408e4408b66337b5, swap.defillama.com:polygon:0xdef1c0ded9bec7f1a1670819833240f027b25eff, mint.eigenlayer.xyz:ethereum:0x8d0802559775c70fb505f22988a4fd4a4f6d3b62, starkgate.starknet.io:ethereum:0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419, portal.zksync.io:ethereum:0x32400084c286cf3e17e7b677ea9583e60a000324, thegraph.com:ethereum:0xf55041e37e12cd407ad00ce2910b8269b01263b9, zora.co:ethereum:0x1a0ad011913a150f69f6a19df447a0cfd9551054, swap.defillama.com:polygon:0xb31d1b1ea48ce4bf10ed697d44b747287e785ad4
  - removed : ...
  - updated : ...

## Reason
Adding 7 new domains and 16 new     dapp->chain->contract entries from the Ledger CDN registry on         Kleros Curate (https://curate.kleros.io/tcr/100/0x957a53a994860be4750810131d9c876b2f52d6e1?registered=true)             up till 10/09/2023 01:54 UTC.
